### PR TITLE
fix: Resolve critical SQLAlchemy and Pydantic startup errors

### DIFF
--- a/core/config.py
+++ b/core/config.py
@@ -1,8 +1,6 @@
 import os
 from typing import Optional
 from pydantic_settings import BaseSettings
-from pydantic import validator
-
 class Settings(BaseSettings):
     # Application
     APP_NAME: str = "Labanita API"
@@ -54,12 +52,6 @@ class Settings(BaseSettings):
     # Google OAuth
     GOOGLE_CLIENT_ID: Optional[str] = None
     GOOGLE_CLIENT_SECRET: Optional[str] = None
-    
-    @validator("DATABASE_URL", "SECRET_KEY", "JWT_SECRET_KEY")
-    def validate_required_settings(cls, v, field):
-        if not v:
-            raise ValueError(f"{field.name} is required")
-        return v
     
     class Config:
         env_file = ".env"


### PR DESCRIPTION
This commit addresses two separate critical errors that prevented the application from starting.

1.  **SQLAlchemy Duplicate Model Definition:**
    - Resolves an `InvalidRequestError` caused by the `User` model being defined in both `models.py` and `auth/models.py`.
    - The fix consolidates all data models into the central `models.py` file, creating a single source of truth and removing the duplicate definition.
    - All import paths have been updated accordingly.

2.  **Pydantic V2 Validator Incompatibility:**
    - Resolves a `PydanticUserError` in `core/config.py` caused by a deprecated Pydantic V1 validator.
    - The fix removes the redundant validator, as Pydantic's default behavior already enforces the required fields, simplifying the code and ensuring compatibility with Pydantic V2.